### PR TITLE
Add check for duplicate event. Fixes #7

### DIFF
--- a/Logger.py
+++ b/Logger.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from Configuration import Configuration
 
+
 class LogLevel(IntEnum):
     Status = auto()
     Warning = auto()

--- a/TicketFolderHandler.py
+++ b/TicketFolderHandler.py
@@ -23,6 +23,8 @@ class TicketFolderHandler(PatternMatchingEventHandler):
                          ignore_directories=True, ignore_patterns=[f"{config_handler.config.done_folder}/*.pdf"])
         self.config = config_handler.config
 
+        self.last_processed: Path | None = None
+
         try:
             self._gsh = GServicesHandler(self.config)
         except Exception as error:
@@ -39,13 +41,21 @@ class TicketFolderHandler(PatternMatchingEventHandler):
     def on_created(self: Self, event: DirCreatedEvent | FileCreatedEvent) -> None:
         if isinstance(event.src_path, str):
             ticket_fp = Path(event.src_path)
+
+            # If this is a duplicate event
+            if self.last_processed and self.last_processed == ticket_fp:
+                log(LogLevel.Status, self.config,
+                    f"Identified duplicate event. Not processing {ticket_fp}")
+                return
+
+            self.last_processed = ticket_fp
+
             if self._wait_for_transfer_completion(ticket_fp, self.config):
                 notify("Detected New Ticket",
                        f"Processing {event.src_path}", self.config)
 
                 self._process_ticket(ticket_fp, self._gsh,
                                      self._model, self.config, True)
-
             else:
                 notify("Skipping Ticket",
                        f"{event.src_path} due to timeout", self.config)

--- a/common.py
+++ b/common.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Type
 if TYPE_CHECKING:
     from Configuration import Configuration
 
+
 class ReminderNotificationType(IntEnum):
     popup = auto()
     email = auto()
@@ -31,6 +32,7 @@ class CalendarEventColor(IntEnum):
 
 SCOPES = ["https://www.googleapis.com/auth/calendar.events.owned",
           "https://www.googleapis.com/auth/drive.file"]
+
 
 CONFIGURATION_FOLDER = Path.home() / ".config/Travel Ticket Calendar"
 


### PR DESCRIPTION
I just check if the last processed file is the same as the one currently being processed. If this is the case then don't process it. No time based deboucing or anything of that sort